### PR TITLE
Add tuples and patterns to ast and a parser for them 

### DIFF
--- a/JaML/lib/ast.ml
+++ b/JaML/lib/ast.ml
@@ -25,25 +25,33 @@ type bin_op =
   | Lte (** a <= b *)
 [@@deriving show { with_path = false }]
 
+type pattern =
+  | PConst of const
+  | PVar of string
+  | PWildcard
+  | PTuple of pattern list
+[@@deriving show { with_path = false }]
+
 (** Expression type *)
 type expr =
   | EConst of const (** An expression for the constant *)
   | EVar of string (** An expression for the variables *)
+  | ETuple of expr list (** An expression for the tuples *)
   | EBinop of bin_op * expr * expr
   (** An expression for the binary operations: +, -, *, / ... *)
   | EApp of expr * expr (** An expression for the function application to the arguments *)
   | EIfThenElse of expr * expr * expr
   (** An expression for condition statement: if expr then expr else expr *)
-  | ELetIn of string * expr * expr
+  | ELetIn of pattern * expr * expr
   (** An expression for let in declaration: let id = expr in expr *)
   | ELetRecIn of string * expr * expr
   (** An expression for let rec in declaration: let rec id = expr in expr *)
-  | EFun of string * expr (** An expression for function: fun id -> expr *)
+  | EFun of pattern * expr (** An expression for function: fun pattern -> expr *)
 [@@deriving show { with_path = false }]
 
 (** Binding type *)
 type bindings =
-  | ELet of string * expr (** An expression for let declaration: let id = expr *)
+  | ELet of pattern * expr (** An expression for let declaration: let id = expr *)
   | ELetRec of string * expr
   (** An expression for let rec declaration: let rec id = expr *)
 [@@deriving show { with_path = false }]

--- a/JaML/lib/inferencer.ml
+++ b/JaML/lib/inferencer.ml
@@ -362,7 +362,7 @@ let infer_expr =
         ( final_subst
         , Subst.apply final_subst t2
         , tifthenelse te1 te2 te3 (Subst.apply final_subst t2) )
-    | ELetIn (name, e1, e2) ->
+    | ELetIn (PVar name, e1, e2) ->
       let* s1, t1_typ, te1 = helper env e1 in
       let env2 = TypeEnv.apply s1 env in
       let t1 = generalize env2 t1_typ in
@@ -380,7 +380,7 @@ let infer_expr =
       let* s2, t2, te2 = helper TypeEnv.(extend (apply s env) (name, t2)) e2 in
       let* final_subst = Subst.compose s s2 in
       return (final_subst, t2, tletrecin name te1 te2 t1)
-    | EFun (arg, e) ->
+    | EFun (PVar arg, e) ->
       let* tv = fresh_var in
       let env = TypeEnv.extend env (arg, S (VarSet.empty, tv)) in
       let* s1, t1, te1 = helper env e in
@@ -394,7 +394,7 @@ let infer_binding env =
   let open Ast in
   let open Typedtree in
   function
-  | ELet (name, e) ->
+  | ELet (PVar name, e) ->
     let* s, t, te = infer_expr env e in
     return (s, t, tlet name te t)
   | ELetRec (name, e) ->
@@ -446,7 +446,7 @@ let infer_statements (bindings : Ast.statements) : tbinding list t =
       ~init:(return (empty, []))
       ~f:(fun env_binding ->
         function
-        | (ELet (name, _) | ELetRec (name, _)) as new_binding ->
+        | (ELet (PVar name, _) | ELetRec (name, _)) as new_binding ->
           let* env, tbindings = env_binding in
           let* subst, ty, tbinding = infer_binding env new_binding in
           return

--- a/JaML/lib/parser.ml
+++ b/JaML/lib/parser.ml
@@ -235,13 +235,15 @@ let elet_fun_in_p expr_p =
 let pack =
   let econst pack = fix @@ fun _ -> econst_p <|> parens @@ pack.econst pack in
   let evar pack = fix @@ fun _ -> evar_p <|> parens @@ pack.evar pack in
+  let letsin pack = pack.eletin pack <|> pack.eletrecin pack in
   let etuple pack =
     fix
     @@ fun _ ->
-    let parsers = parens_or_not_asc @@ (pack.evar pack <|> pack.econst pack) in
+    let parsers =
+      pack.ebinop pack <|> pack.eapply pack <|> pack.econdition pack <|> pack.efun pack
+    in
     etuple_p (parens @@ pack.etuple pack <|> parsers) <|> parens @@ pack.etuple pack
   in
-  let letsin pack = pack.eletin pack <|> pack.eletrecin pack in
   let expr pack =
     pack.ebinop pack
     <|> pack.etuple pack
@@ -281,6 +283,7 @@ let pack =
     @@ fun _ ->
     let efun_parse =
       pack.ebinop pack
+      <|> pack.etuple pack
       <|> pack.eapply pack
       <|> pack.econdition pack
       <|> pack.efun pack
@@ -303,9 +306,9 @@ let pack =
          <|> pack.eapply pack
          <|> pack.efun pack
          <|> letsin pack)
-      <|> pack.etuple pack
       <|> pack.evar pack
       <|> pack.econst pack
+      <|> parens_or_not_asc @@ pack.etuple pack
     in
     eapp_p (eapply_fun pack) (eapply_parse pack) <|> parens @@ pack.eapply pack
   in

--- a/JaML/lib/parser.ml
+++ b/JaML/lib/parser.ml
@@ -37,9 +37,11 @@ let wspace_l p = empty *> p
 let wspaces_char ch = wspace_l @@ char ch
 let wspaces_str str = wspaces_p @@ string_ci str
 let parens p = wspaces_char '(' *> p <* wspaces_char ')'
-let parens_or_not p = p <|> parens p
+let parens_or_not_desc p = p <|> parens p
+let parens_or_not_asc p = parens p <|> p
 let cint i = CInt i
 let cbool b = CBool b
+let wc_p = empty *> wspaces_char '_'
 
 let var_p =
   empty *> take_while1 (fun ch -> is_letter ch || is_digit ch || Char.equal ch '_')
@@ -48,6 +50,8 @@ let var_p =
   then fail "Variables cannot be keyword"
   else if is_digit @@ String.get v 0
   then fail "The first character must be a letter"
+  else if String.get v 0 = '_' && String.length v = 1
+  then fail "The variable cannot be named wildcard"
   else return v
 ;;
 
@@ -68,14 +72,55 @@ let cbool_p =
   *> lift (fun b -> cbool @@ bool_of_string b) (wspaces_str "false" <|> wspaces_str "true")
 ;;
 
+let const_p = cint_p <|> cbool_p
+
 let chainl1 e op =
   let rec go acc = lift2 (fun f x -> f acc x) op e >>= go <|> return acc in
   e >>= fun init -> go init
 ;;
 
+type pdispatch =
+  { value : pdispatch -> pattern t
+  ; ptuple : pdispatch -> pattern t
+  ; pattern : pdispatch -> pattern t (** Parser for patterns in arguments *)
+  ; pattern_name : pdispatch -> pattern t
+  (** Parser for patterns when declaring a function or variables *)
+  }
+
+let pvar_p = (fun v -> PVar v) <$> var_p
+let pconst_p = (fun c -> PConst c) <$> const_p
+let pwc_p = (fun _ -> PWildcard) <$> wc_p
+
+let tuple_p p =
+  empty
+  *> lift2
+       (fun a b -> a :: b)
+       (wspaces_p p <* wspaces_char ',')
+       (sep_by1 (wspaces_char ',') p)
+;;
+
+let ptuple_p p = (fun t -> PTuple t) <$> parens_or_not_asc @@ tuple_p p
+
+let pack =
+  let pattern pack = pack.ptuple pack <|> pack.value pack in
+  let pattern_name pack = pack.ptuple pack <|> pwc_p <|> pvar_p in
+  let value _ = parens_or_not_desc @@ (pwc_p <|> pvar_p <|> pconst_p) in
+  let ptuple pack =
+    fix
+    @@ fun _ ->
+    ptuple_p (parens @@ pack.ptuple pack <|> pack.value pack)
+    <|> parens @@ pack.ptuple pack
+  in
+  { value; ptuple; pattern; pattern_name }
+;;
+
+let patt_p = pack.pattern pack
+let patt_name_p = pack.pattern_name pack
+
 type edispatch =
   { evar : edispatch -> expr t
   ; econst : edispatch -> expr t
+  ; etuple : edispatch -> expr t
   ; econdition : edispatch -> expr t
   ; eletin : edispatch -> expr t
   ; eletrecin : edispatch -> expr t
@@ -85,9 +130,9 @@ type edispatch =
   ; expr : edispatch -> expr t
   }
 
-let const_p = cint_p <|> cbool_p
 let econst_p = (fun v -> EConst v) <$> const_p
 let evar_p = (fun v -> EVar v) <$> var_p
+let etuple_p p = (fun t -> ETuple t) <$> parens_or_not_asc @@ tuple_p p
 
 let ebinop_p expr =
   let helper p op = empty *> p *> return (fun e1 e2 -> EBinop (op, e1, e2)) in
@@ -125,8 +170,8 @@ let eapp_p expr_p1 expr_p2 =
        (many1 @@ (empty1 *> expr_p2))
 ;;
 
-let fun_args_p = many (parens_or_not var_p)
-let fun_args_p1 = many1 (parens_or_not var_p)
+let fun_args_p = many (parens_or_not_desc patt_p)
+let fun_args_p1 = many1 (parens_or_not_desc patt_p)
 let efun args body = List.fold_right (fun arg acc -> EFun (arg, acc)) args body
 
 let econd pif expr_p =
@@ -146,44 +191,60 @@ let efun_p expr_p =
        (wspaces_str "->" *> expr_p)
 ;;
 
-let rec_p = wspaces_str "let" *> option None ((fun r -> Some r) <$> wspaces_str "rec")
+let rec_p = wspaces_str "let" *> wspaces_str "rec"
+let let_p = wspaces_str "let"
 
 let elet_fun_p expr_p =
   empty
-  *> lift4
-       (fun opt name args body ->
-         let body = efun args body in
-         match opt with
-         | None -> ELet (name, body)
-         | Some _ -> ELetRec (name, body))
-       rec_p
-       var_p
-       fun_args_p
-       (wspaces_str "=" *> expr_p)
+  *> (lift3
+        (fun name args body ->
+          let body = efun args body in
+          ELetRec (name, body))
+        (rec_p *> var_p)
+        fun_args_p
+        (wspaces_str "=" *> expr_p)
+      <|> lift3
+            (fun name args body ->
+              let body = efun args body in
+              ELet (name, body))
+            (let_p *> patt_name_p)
+            fun_args_p
+            (wspaces_str "=" *> expr_p))
 ;;
 
 let elet_fun_in_p expr_p =
-  let lift5 f p1 p2 p3 p4 p5 = f <$> p1 <*> p2 <*> p3 <*> p4 <*> p5 in
   empty
-  *> lift5
-       (fun opt name args body1 body2 ->
-         let body1 = efun args body1 in
-         match opt with
-         | None -> ELetIn (name, body1, body2)
-         | Some _ -> ELetRecIn (name, body1, body2))
-       rec_p
-       var_p
-       fun_args_p
-       (wspaces_str "=" *> expr_p)
-       (wspaces_str "in" *> expr_p)
+  *> (lift4
+        (fun name args body1 body2 ->
+          let body1 = efun args body1 in
+          ELetRecIn (name, body1, body2))
+        (rec_p *> var_p)
+        fun_args_p
+        (wspaces_str "=" *> expr_p)
+        (wspaces_str "in" *> expr_p)
+      <|> lift4
+            (fun name args body1 body2 ->
+              let body1 = efun args body1 in
+              ELetIn (name, body1, body2))
+            (let_p *> patt_name_p)
+            fun_args_p
+            (wspaces_str "=" *> expr_p)
+            (wspaces_str "in" *> expr_p))
 ;;
 
 let pack =
   let econst pack = fix @@ fun _ -> econst_p <|> parens @@ pack.econst pack in
   let evar pack = fix @@ fun _ -> evar_p <|> parens @@ pack.evar pack in
+  let etuple pack =
+    fix
+    @@ fun _ ->
+    let parsers = parens_or_not_asc @@ (pack.evar pack <|> pack.econst pack) in
+    etuple_p (parens @@ pack.etuple pack <|> parsers) <|> parens @@ pack.etuple pack
+  in
   let letsin pack = pack.eletin pack <|> pack.eletrecin pack in
   let expr pack =
     pack.ebinop pack
+    <|> pack.etuple pack
     <|> pack.eapply pack
     <|> pack.econdition pack
     <|> pack.efun pack
@@ -242,6 +303,7 @@ let pack =
          <|> pack.eapply pack
          <|> pack.efun pack
          <|> letsin pack)
+      <|> pack.etuple pack
       <|> pack.evar pack
       <|> pack.econst pack
     in
@@ -253,7 +315,7 @@ let pack =
   let eletrecin pack =
     fix @@ fun _ -> elet_fun_in_p @@ pack.expr pack <|> parens @@ pack.eletrecin pack
   in
-  { evar; econst; ebinop; econdition; efun; eletin; eletrecin; eapply; expr }
+  { evar; econst; ebinop; etuple; econdition; efun; eletin; eletrecin; eapply; expr }
 ;;
 
 let expr_p = wspaces_p @@ pack.expr pack

--- a/JaML/lib/parser.mli
+++ b/JaML/lib/parser.mli
@@ -10,6 +10,9 @@ val pp_error : Format.formatter -> error -> unit
 (** Parser of constant *)
 val const_p : Ast.const Angstrom.t
 
+(** Parser of pattern *)
+val patt_p : Ast.pattern Angstrom.t
+
 (** Parser of expression *)
 val expr_p : Ast.expr Angstrom.t
 

--- a/JaML/lib/tests/infer_tests.ml
+++ b/JaML/lib/tests/infer_tests.ml
@@ -507,7 +507,7 @@ let%expect_test _ =
 let%expect_test _ =
   let open Jaml_lib.Ast in
   let _ =
-    let e = EFun ("x", EVar "x") in
+    let e = EFun (PVar "x", EVar "x") in
     infer_expr e |> run_infer_expr
   in
   [%expect {|
@@ -521,7 +521,7 @@ let%expect_test _ =
 let%expect_test _ =
   let open Jaml_lib.Ast in
   let _ =
-    let e = EFun ("x", EConst (CInt 1)) in
+    let e = EFun (PVar "x", EConst (CInt 1)) in
     infer_expr e |> run_infer_expr
   in
   [%expect
@@ -536,7 +536,7 @@ let%expect_test _ =
 let%expect_test _ =
   let open Jaml_lib.Ast in
   let _ =
-    let e = EFun ("x", EConst (CBool false)) in
+    let e = EFun (PVar "x", EConst (CBool false)) in
     infer_expr e |> run_infer_expr
   in
   [%expect
@@ -611,7 +611,9 @@ let%expect_test _ =
 let%expect_test _ =
   let open Jaml_lib.Ast in
   let _ =
-    let e = ELetIn ("id", EFun ("x", EVar "x"), EApp (EVar "id", EConst (CInt 1))) in
+    let e =
+      ELetIn (PVar "id", EFun (PVar "x", EVar "x"), EApp (EVar "id", EConst (CInt 1)))
+    in
     infer_expr e |> run_infer_expr
   in
   [%expect
@@ -635,7 +637,7 @@ let%expect_test _ =
 let%expect_test _ =
   let open Jaml_lib.Ast in
   let _ =
-    let e = [ ELet ("result", EConst (CBool true)) ] in
+    let e = [ ELet (PVar "result", EConst (CBool true)) ] in
     infer_statements e |> run_infer_statements
   in
   [%expect
@@ -650,7 +652,7 @@ let%expect_test _ =
 let%expect_test _ =
   let open Jaml_lib.Ast in
   let _ =
-    let e = [ ELet ("result", EConst (CInt 4)) ] in
+    let e = [ ELet (PVar "result", EConst (CInt 4)) ] in
     infer_statements e |> run_infer_statements
   in
   [%expect {|
@@ -664,7 +666,7 @@ let%expect_test _ =
 let%expect_test _ =
   let open Jaml_lib.Ast in
   let _ =
-    let e = [ ELet ("result", EFun ("x", EVar "x")) ] in
+    let e = [ ELet (PVar "result", EFun (PVar "x", EVar "x")) ] in
     infer_statements e |> run_infer_statements
   in
   [%expect
@@ -682,7 +684,7 @@ let%expect_test _ =
 let%expect_test _ =
   let open Jaml_lib.Ast in
   let _ =
-    let e = [ ELet ("result", EFun ("x", EConst (CInt 5))) ] in
+    let e = [ ELet (PVar "result", EFun (PVar "x", EConst (CInt 5))) ] in
     infer_statements e |> run_infer_statements
   in
   [%expect
@@ -702,15 +704,15 @@ let%expect_test _ =
   let _ =
     let e =
       [ ELet
-          ( "sum4"
+          ( PVar "sum4"
           , EFun
-              ( "x"
+              ( PVar "x"
               , EFun
-                  ( "y"
+                  ( PVar "y"
                   , EFun
-                      ( "z"
+                      ( PVar "z"
                       , EFun
-                          ( "w"
+                          ( PVar "w"
                           , EBinop
                               ( Add
                               , EBinop (Add, EVar "x", EVar "y")
@@ -752,7 +754,9 @@ let%expect_test _ =
 let%expect_test _ =
   let open Jaml_lib.Ast in
   let _ =
-    let e = [ ELet ("apply", EFun ("f", EFun ("a", EApp (EVar "f", EVar "a")))) ] in
+    let e =
+      [ ELet (PVar "apply", EFun (PVar "f", EFun (PVar "a", EApp (EVar "f", EVar "a")))) ]
+    in
     infer_statements e |> run_infer_statements
   in
   [%expect
@@ -779,19 +783,19 @@ let%expect_test _ =
   let _ =
     let e =
       [ ELet
-          ( "apply5"
+          ( PVar "apply5"
           , EFun
-              ( "function"
+              ( PVar "function"
               , EFun
-                  ( "a"
+                  ( PVar "a"
                   , EFun
-                      ( "b"
+                      ( PVar "b"
                       , EFun
-                          ( "c"
+                          ( PVar "c"
                           , EFun
-                              ( "d"
+                              ( PVar "d"
                               , EFun
-                                  ( "e"
+                                  ( PVar "e"
                                   , EApp
                                       ( EApp
                                           ( EApp
@@ -854,13 +858,13 @@ let%expect_test _ =
   let _ =
     let e =
       [ ELet
-          ( "sumn"
+          ( PVar "sumn"
           , EFun
-              ( "x"
+              ( PVar "x"
               , ELetRecIn
                   ( "helper"
                   , EFun
-                      ( "x"
+                      ( PVar "x"
                       , EIfThenElse
                           ( EBinop (Eq, EVar "x", EConst (CInt 1))
                           , EConst (CInt 1)
@@ -915,7 +919,7 @@ let%expect_test _ =
       [ ELetRec
           ( "fact"
           , EFun
-              ( "n"
+              ( PVar "n"
               , EIfThenElse
                   ( EBinop (Eq, EVar "n", EConst (CInt 1))
                   , EConst (CInt 1)
@@ -964,15 +968,15 @@ let%expect_test _ =
   let _ =
     let e =
       [ ELet
-          ( "fac"
+          ( PVar "fac"
           , EFun
-              ( "n"
+              ( PVar "n"
               , ELetRecIn
                   ( "fact"
                   , EFun
-                      ( "n"
+                      ( PVar "n"
                       , EFun
-                          ( "acc"
+                          ( PVar "acc"
                           , EIfThenElse
                               ( EBinop (Lt, EVar "n", EConst (CInt 1))
                               , EVar "acc"
@@ -1037,7 +1041,7 @@ let%expect_test _ =
   let open Jaml_lib.Ast in
   let _ =
     let e =
-      [ ELetRec ("fix", EFun ("f", EApp (EVar "f", EApp (EVar "fix", EVar "f")))) ]
+      [ ELetRec ("fix", EFun (PVar "f", EApp (EVar "f", EApp (EVar "fix", EVar "f")))) ]
     in
     infer_statements e |> run_infer_statements
   in
@@ -1066,10 +1070,10 @@ let%expect_test _ =
       [ ELetRec
           ( "fix"
           , EFun
-              ( "f"
+              ( PVar "f"
               , EFun
-                  ("eta", EApp (EApp (EVar "f", EApp (EVar "fix", EVar "f")), EVar "eta"))
-              ) )
+                  ( PVar "eta"
+                  , EApp (EApp (EVar "f", EApp (EVar "fix", EVar "f")), EVar "eta") ) ) )
       ]
     in
     infer_statements e |> run_infer_statements

--- a/JaML/lib/tests/parser_test.ml
+++ b/JaML/lib/tests/parser_test.ml
@@ -115,7 +115,7 @@ let%expect_test _ =
 
 let%expect_test _ =
   interpret_parse show_bindings bindings_p "let x y = y";
-  [%expect {| (ELet ("x", (EFun ("y", (EVar "y"))))) |}]
+  [%expect {| (ELet ((PVar "x"), (EFun ((PVar "y"), (EVar "y"))))) |}]
 ;;
 
 let%expect_test _ =
@@ -135,9 +135,9 @@ let%expect_test _ =
   interpret_parse show_expr expr_p "fun x y z -> x + y - z";
   [%expect
     {|
-    (EFun ("x",
-       (EFun ("y",
-          (EFun ("z",
+    (EFun ((PVar "x"),
+       (EFun ((PVar "y"),
+          (EFun ((PVar "z"),
              (EBinop (Sub, (EBinop (Add, (EVar "x"), (EVar "y"))), (EVar "z")))))
           ))
        )) |}]
@@ -145,33 +145,176 @@ let%expect_test _ =
 
 let%expect_test _ =
   interpret_parse show_bindings bindings_p "let x y = y * y";
-  [%expect {|
-    (ELet ("x", (EFun ("y", (EBinop (Mul, (EVar "y"), (EVar "y"))))))) |}]
+  [%expect
+    {|
+    (ELet ((PVar "x"),
+       (EFun ((PVar "y"), (EBinop (Mul, (EVar "y"), (EVar "y"))))))) |}]
 ;;
 
 let%expect_test _ =
   interpret_parse show_bindings bindings_p "let x y = y * y";
-  [%expect {| (ELet ("x", (EFun ("y", (EBinop (Mul, (EVar "y"), (EVar "y"))))))) |}]
+  [%expect
+    {|
+    (ELet ((PVar "x"),
+       (EFun ((PVar "y"), (EBinop (Mul, (EVar "y"), (EVar "y"))))))) |}]
 ;;
 
 let%expect_test _ =
   interpret_parse show_bindings bindings_p "let x = fun y -> y * y";
-  [%expect {| (ELet ("x", (EFun ("y", (EBinop (Mul, (EVar "y"), (EVar "y"))))))) |}]
+  [%expect
+    {|
+    (ELet ((PVar "x"),
+       (EFun ((PVar "y"), (EBinop (Mul, (EVar "y"), (EVar "y"))))))) |}]
+;;
+
+let%expect_test _ =
+  interpret_parse show_pattern patt_p "a,1,c";
+  [%expect {| (PTuple [(PVar "a"); (PConst (CInt 1)); (PVar "c")]) |}]
+;;
+
+let%expect_test _ =
+  interpret_parse show_pattern patt_p "_,_";
+  [%expect {| (PTuple [PWildcard; PWildcard]) |}]
+;;
+
+let%expect_test _ =
+  interpret_parse show_pattern patt_p "((a, (b, c),(d, (e, g),(h, j))),(i, k))";
+  [%expect {|
+    (PTuple
+       [(PTuple
+           [(PVar "a"); (PTuple [(PVar "b"); (PVar "c")]);
+             (PTuple
+                [(PVar "d"); (PTuple [(PVar "e"); (PVar "g")]);
+                  (PTuple [(PVar "h"); (PVar "j")])])
+             ]);
+         (PTuple [(PVar "i"); (PVar "k")])])
+   |}]
+;;
+
+let%expect_test _ =
+  interpret_parse show_statements statements_p "let f (a, b, _, d) = (a, b, d)";
+  [%expect {|
+    [(ELet ((PVar "f"),
+        (EFun ((PTuple [(PVar "a"); (PVar "b"); PWildcard; (PVar "d")]),
+           (ETuple [(EVar "a"); (EVar "b"); (EVar "d")])))
+        ))
+      ]
+   |}]
+;;
+
+let%expect_test _ =
+  interpret_parse
+    show_statements
+    statements_p
+    "let apply_tuple_to_function func a b c = func (a, b, c)";
+  [%expect {|
+    [(ELet ((PVar "apply_tuple_to_function"),
+        (EFun ((PVar "func"),
+           (EFun ((PVar "a"),
+              (EFun ((PVar "b"),
+                 (EFun ((PVar "c"),
+                    (EApp ((EVar "func"),
+                       (ETuple [(EVar "a"); (EVar "b"); (EVar "c")])))
+                    ))
+                 ))
+              ))
+           ))
+        ))
+      ]
+   |}]
+;;
+
+let%expect_test _ =
+  interpret_parse show_statements statements_p "let const _ = 1";
+  [%expect {| [(ELet ((PVar "const"), (EFun (PWildcard, (EConst (CInt 1))))))] |}]
+;;
+
+let%expect_test _ =
+  interpret_parse
+    show_statements
+    statements_p
+    "let strange_tuple ((a, (b, c),(d, (e, g),(h, j))),(i, k)) = ((a, b, c, d), (e, g, \
+     h, j), (i, k))";
+  [%expect {|
+    [(ELet ((PVar "strange_tuple"),
+        (EFun (
+           (PTuple
+              [(PTuple
+                  [(PVar "a"); (PTuple [(PVar "b"); (PVar "c")]);
+                    (PTuple
+                       [(PVar "d"); (PTuple [(PVar "e"); (PVar "g")]);
+                         (PTuple [(PVar "h"); (PVar "j")])])
+                    ]);
+                (PTuple [(PVar "i"); (PVar "k")])]),
+           (ETuple
+              [(ETuple [(EVar "a"); (EVar "b"); (EVar "c"); (EVar "d")]);
+                (ETuple [(EVar "e"); (EVar "g"); (EVar "h"); (EVar "j")]);
+                (ETuple [(EVar "i"); (EVar "k")])])
+           ))
+        ))
+      ]
+   |}]
+;;
+
+let%expect_test _ =
+  interpret_parse show_statements statements_p "let fst_sum (a, _) (c, _) = a + c";
+  [%expect {|
+    [(ELet ((PVar "fst_sum"),
+        (EFun ((PTuple [(PVar "a"); PWildcard]),
+           (EFun ((PTuple [(PVar "c"); PWildcard]),
+              (EBinop (Add, (EVar "a"), (EVar "c")))))
+           ))
+        ))
+      ]
+   |}]
+;;
+
+let%expect_test _ =
+  interpret_parse
+    show_statements
+    statements_p
+    "let f (((((((((((a,b))))), ((((((c, d)))))))))))) = a + b + c + d";
+  [%expect {|
+    [(ELet ((PVar "f"),
+        (EFun (
+           (PTuple
+              [(PTuple [(PVar "a"); (PVar "b")]);
+                (PTuple [(PVar "c"); (PVar "d")])]),
+           (EBinop (Add,
+              (EBinop (Add, (EBinop (Add, (EVar "a"), (EVar "b"))), (EVar "c"))),
+              (EVar "d")))
+           ))
+        ))
+      ]
+   |}]
+;;
+
+let%expect_test _ =
+  interpret_parse show_statements statements_p "let f (a, b) = a + b";
+  [%expect {|
+    [(ELet ((PVar "f"),
+        (EFun ((PTuple [(PVar "a"); (PVar "b")]),
+           (EBinop (Add, (EVar "a"), (EVar "b")))))
+        ))
+      ]
+   |}]
 ;;
 
 let%expect_test _ =
   interpret_parse show_bindings bindings_p "let apply f x = f x";
   [%expect
     {|
-      (ELet ("apply", (EFun ("f", (EFun ("x", (EApp ((EVar "f"), (EVar "x"))))))))) |}]
+      (ELet ((PVar "apply"),
+         (EFun ((PVar "f"), (EFun ((PVar "x"), (EApp ((EVar "f"), (EVar "x")))))))
+         )) |}]
 ;;
 
 let%expect_test _ =
   interpret_parse show_bindings bindings_p "let x y = if y > 0 then y else 0";
   [%expect
     {|
-    (ELet ("x",
-       (EFun ("y",
+    (ELet ((PVar "x"),
+       (EFun ((PVar "y"),
           (EIfThenElse ((EBinop (Gt, (EVar "y"), (EConst (CInt 0)))), (EVar "y"),
              (EConst (CInt 0))))
           ))
@@ -186,7 +329,7 @@ let%expect_test _ =
   [%expect
     {|
     [(ELetRec ("fib",
-        (EFun ("n",
+        (EFun ((PVar "n"),
            (EIfThenElse ((EBinop (Lt, (EVar "n"), (EConst (CInt 1)))),
               (EConst (CInt 1)),
               (EBinop (Add,
@@ -208,8 +351,9 @@ let%expect_test _ =
     "let square = fun x -> x * x  let square5 = square 5";
   [%expect
     {|
-    [(ELet ("square", (EFun ("x", (EBinop (Mul, (EVar "x"), (EVar "x")))))));
-      (ELet ("square5", (EApp ((EVar "square"), (EConst (CInt 5))))))]|}]
+    [(ELet ((PVar "square"),
+        (EFun ((PVar "x"), (EBinop (Mul, (EVar "x"), (EVar "x")))))));
+      (ELet ((PVar "square5"), (EApp ((EVar "square"), (EConst (CInt 5))))))]|}]
 ;;
 
 let%expect_test _ =
@@ -222,11 +366,11 @@ let%expect_test _ =
     \    let fac5 = fac 5";
   [%expect
     {|
-    [(ELet ("fac",
-        (EFun ("n",
+    [(ELet ((PVar "fac"),
+        (EFun ((PVar "n"),
            (ELetRecIn ("fact",
-              (EFun ("n",
-                 (EFun ("acc",
+              (EFun ((PVar "n"),
+                 (EFun ((PVar "acc"),
                     (EIfThenElse ((EBinop (Lt, (EVar "n"), (EConst (CInt 1)))),
                        (EVar "acc"),
                        (EApp (
@@ -239,7 +383,7 @@ let%expect_test _ =
               (EApp ((EApp ((EVar "fact"), (EVar "n"))), (EConst (CInt 1))))))
            ))
         ));
-      (ELet ("fac5", (EApp ((EVar "fac"), (EConst (CInt 5))))))] |}]
+      (ELet ((PVar "fac5"), (EApp ((EVar "fac"), (EConst (CInt 5))))))] |}]
 ;;
 
 let%expect_test _ =
@@ -247,7 +391,9 @@ let%expect_test _ =
   [%expect
     {|
     [(ELetRec ("fix",
-        (EFun ("f", (EApp ((EVar "f"), (EApp ((EVar "fix"), (EVar "f")))))))))
+        (EFun ((PVar "f"), (EApp ((EVar "f"), (EApp ((EVar "fix"), (EVar "f")))))
+           ))
+        ))
       ]
    |}]
 ;;
@@ -257,8 +403,8 @@ let%expect_test _ =
   [%expect
     {|
     [(ELetRec ("fix",
-        (EFun ("f",
-           (EFun ("eta",
+        (EFun ((PVar "f"),
+           (EFun ((PVar "eta"),
               (EApp ((EApp ((EVar "f"), (EApp ((EVar "fix"), (EVar "f"))))),
                  (EVar "eta")))
               ))
@@ -275,11 +421,13 @@ let%expect_test _ =
     "let fix f = (fun x -> f (x x)) (fun y -> f (y y))";
   [%expect
     {|
-    [(ELet ("fix",
-        (EFun ("f",
+    [(ELet ((PVar "fix"),
+        (EFun ((PVar "f"),
            (EApp (
-              (EFun ("x", (EApp ((EVar "f"), (EApp ((EVar "x"), (EVar "x"))))))),
-              (EFun ("y", (EApp ((EVar "f"), (EApp ((EVar "y"), (EVar "y")))))))
+              (EFun ((PVar "x"),
+                 (EApp ((EVar "f"), (EApp ((EVar "x"), (EVar "x"))))))),
+              (EFun ((PVar "y"),
+                 (EApp ((EVar "f"), (EApp ((EVar "y"), (EVar "y")))))))
               ))
            ))
         ))


### PR DESCRIPTION
Изменено аст добавлением кортежей и паттернов. Изменен парсер и исправлены баги в инференсере после изменения аст. Добавлены тесты.

Поддержка кортежей добавляется в рамках #11 